### PR TITLE
S5_US1-affichagePhotoProfil

### DIFF
--- a/frontend/src/layout/navbar/Navbar.module.scss
+++ b/frontend/src/layout/navbar/Navbar.module.scss
@@ -104,6 +104,7 @@ nav ul {
     width: 3rem;
     border-radius: 50px;
     display: block;
+    margin-right: 40px;
   }
   .btnConnection:hover {
     background: linear-gradient(rgba(137, 139, 177, 1), black);


### PR DESCRIPTION
S5_US1-affichagePhotoProfil En temps qu'utilisateur je peux voir la photo de profil en entier

correctif css sur la navbar